### PR TITLE
Fix image getting cut off on small widths

### DIFF
--- a/lapis-k.css
+++ b/lapis-k.css
@@ -8,7 +8,7 @@
 
     body {
         background: #ECEFF1 !important;
-    }vv
+    }
 
     a,
     .button,

--- a/lapis-k.css
+++ b/lapis-k.css
@@ -8,7 +8,7 @@
 
     body {
         background: #ECEFF1 !important;
-    }
+    }vv
 
     a,
     .button,
@@ -2475,10 +2475,14 @@
         padding: 12px 15px !important;
     }
 
+    ._unit._work-detail-unit .works_display img {
+        max-width: 100% !important;
+    }
+  
     ._unit._work-detail-unit .works_display {
 
         /*** MEMBER ILLUUSTRATION RIGHT CONTENT WORKS ***/
-        width: 40vw !important;
+        width: auto !important;
     }
 
     .read-more.js-click-trackable {


### PR DESCRIPTION
Fixes this:
![billede](https://user-images.githubusercontent.com/11841002/36753906-7cbab324-1bff-11e8-918a-2339acd68df5.png)

Also, removed the 600px limit on images. 